### PR TITLE
Add config hyper v

### DIFF
--- a/packages/courDeCassation/LabelServerProd.service
+++ b/packages/courDeCassation/LabelServerProd.service
@@ -3,9 +3,10 @@ Description=Label server
 After=syslog.target
 
 [Service]
+User=label
 Type=simple
 ExecStart=/usr/bin/yarn startProd
-WorkingDirectory=/home/label
+WorkingDirectory=/home/label/label
 Restart=always
 RestartSec=10
 KillMode=process

--- a/packages/courDeCassation/environments/prodEnvironment.json
+++ b/packages/courDeCassation/environments/prodEnvironment.json
@@ -5,9 +5,9 @@
     "db": "10.5.0.5"
   },
   "pathName": {
-    "nlpApi": "http://127.0.0.1",
-    "server": "http://srvanonym",
-    "db": "mongodb://127.0.0.1"
+    "nlpApi": "http://172.16.117.98",
+    "server": "http://shv7-cass",
+    "db": "mongodb://172.16.118.100"
   },
   "port": {
     "nlpApi": 8081,

--- a/packages/generic/client/src/utils/urlHandler.ts
+++ b/packages/generic/client/src/utils/urlHandler.ts
@@ -10,6 +10,6 @@ const urlHandler = {
 
     const serverPort = environmentHandler.convertClientPortToServerPort(clientPort);
 
-    return `${clientProtocol}//${clientHostname}:${serverPort}`;
+    return serverPort ? `${clientProtocol}//${clientHostname}:${serverPort}` : `${clientProtocol}//${clientHostname}`;
   },
 };


### PR DESCRIPTION
Issue:
- IPs of nlpAPI and mongodb not adapted to hyperv env
- backend port configured relatively to client doesn't work in reverse proxy mode (where both backend and frontend share 443 port)
## Changes
- IPs of nlpAPI and mongodb
- getApiUrl handles no serverPort, so when in http and https assumes backend and front share the same "transpartent" and standard port (80 or 443)