### PR TITLE
Fix/send all priorities to nlp

### DIFF
--- a/packages/courDeCassation/src/connector/mapper/mapCourtDecisionToDocument.ts
+++ b/packages/courDeCassation/src/connector/mapper/mapCourtDecisionToDocument.ts
@@ -184,6 +184,8 @@ function computePriority(
     return 4;
   }
   switch (importer) {
+    case 'manual':
+      return 3;
     case 'chained':
       return 1;
     case 'filler':

--- a/packages/generic/backend/src/lib/annotator/buildAnnotator.ts
+++ b/packages/generic/backend/src/lib/annotator/buildAnnotator.ts
@@ -86,7 +86,7 @@ function buildAnnotator(
     });
 
     const failedDocumentIds: documentType['_id'][] = [];
-    const documentsCountToAnnotate = await documentService.countDocumentsWithoutAnnotations();
+    const documentsCountToAnnotate = await documentService.countLoadedDocuments();
     logger.log({
       operationName: 'annotateDocumentsWithoutAnnotations',
       msg: `Found ${documentsCountToAnnotate} documents to annotate`,

--- a/packages/generic/backend/src/lib/connector/buildConnector.ts
+++ b/packages/generic/backend/src/lib/connector/buildConnector.ts
@@ -93,9 +93,8 @@ function buildConnector(connectorConfig: connectorConfigType) {
 
       logger.log({
         operationName: 'importSpecificDocument',
-        msg: `Court decision found. labelStatus: ${
-          courtDecision.labelStatus
-        }, ${!!courtDecision.pseudoText ? 'already' : 'never'} pseudonymised`,
+        msg: `Court decision found. labelStatus: ${courtDecision.labelStatus
+          }, ${!!courtDecision.pseudoText ? 'already' : 'never'} pseudonymised`,
       });
       const document = await connectorConfig.mapCourtDecisionToDocument(
         courtDecision,
@@ -150,9 +149,8 @@ function buildConnector(connectorConfig: connectorConfigType) {
     const MAX_STEP = 300;
     logger.log({
       operationName: 'importNewDocuments',
-      msg: `START: ${documentsCount} - ${
-        sources?.join('/') ?? 'all sources'
-      } - ${daysStep || DEFAULT_DAYS_STEP}`,
+      msg: `START: ${documentsCount} - ${sources?.join('/') ?? 'all sources'
+        } - ${daysStep || DEFAULT_DAYS_STEP}`,
     });
 
     if (threshold) {
@@ -222,13 +220,12 @@ function buildConnector(connectorConfig: connectorConfigType) {
 
         logger.log({
           operationName: 'importNewDocuments',
-          msg: `${newCourtDecisions.length} ${
-            connectorConfig.name
-          } court decisions fetched between ${timeOperator.convertTimestampToReadableDate(
-            startDate.getTime(),
-          )} and ${timeOperator.convertTimestampToReadableDate(
-            endDate.getTime(),
-          )}!`,
+          msg: `${newCourtDecisions.length} ${connectorConfig.name
+            } court decisions fetched between ${timeOperator.convertTimestampToReadableDate(
+              startDate.getTime(),
+            )} and ${timeOperator.convertTimestampToReadableDate(
+              endDate.getTime(),
+            )}!`,
         });
         for (const courtDecision of newCourtDecisions) {
           newDocuments.push(
@@ -283,9 +280,8 @@ function buildConnector(connectorConfig: connectorConfigType) {
     const MAX_STEP = 300;
     logger.log({
       operationName: 'importNewDocuments',
-      msg: `importChainedDocuments: ${documentCount} - ${
-        daysStep || DEFAULT_DAYS_STEP
-      }`,
+      msg: `importChainedDocuments: ${documentCount} - ${daysStep || DEFAULT_DAYS_STEP
+        }`,
     });
 
     logger.log({
@@ -312,13 +308,12 @@ function buildConnector(connectorConfig: connectorConfigType) {
           )) ?? [];
         logger.log({
           operationName: 'importChainedDocuments',
-          msg: `${newCourtDecisions.length} ${
-            connectorConfig.name
-          } court decisions fetched between ${timeOperator.convertTimestampToReadableDate(
-            startDate.getTime(),
-          )} and ${timeOperator.convertTimestampToReadableDate(
-            endDate.getTime(),
-          )}!`,
+          msg: `${newCourtDecisions.length} ${connectorConfig.name
+            } court decisions fetched between ${timeOperator.convertTimestampToReadableDate(
+              startDate.getTime(),
+            )} and ${timeOperator.convertTimestampToReadableDate(
+              endDate.getTime(),
+            )}!`,
         });
         for (const courtDecision of newCourtDecisions) {
           newDocuments.push(
@@ -390,19 +385,19 @@ function buildConnector(connectorConfig: connectorConfigType) {
       const newJurinetCourtDecisions =
         (byDateCreation
           ? await connectorConfig.fetchDecisionsToPseudonymiseBetweenDateCreation(
-              {
-                startDate: new Date(dateBuilder.daysAgo(days)),
-                endDate: new Date(),
-                source: 'jurinet',
-                environment,
-              },
-            )
-          : await connectorConfig.fetchDecisionsToPseudonymiseBetween({
+            {
               startDate: new Date(dateBuilder.daysAgo(days)),
               endDate: new Date(),
               source: 'jurinet',
               environment,
-            })) ?? [];
+            },
+          )
+          : await connectorConfig.fetchDecisionsToPseudonymiseBetween({
+            startDate: new Date(dateBuilder.daysAgo(days)),
+            endDate: new Date(),
+            source: 'jurinet',
+            environment,
+          })) ?? [];
       logger.log({
         operationName: 'importDocumentsSince',
         msg: `${newJurinetCourtDecisions.length} ${connectorConfig.name} court decisions fetched from jurinet!`,
@@ -423,19 +418,19 @@ function buildConnector(connectorConfig: connectorConfigType) {
       const newJuricaCourtDecisions =
         (byDateCreation
           ? await connectorConfig.fetchDecisionsToPseudonymiseBetweenDateCreation(
-              {
-                startDate: new Date(dateBuilder.daysAgo(days)),
-                endDate: new Date(),
-                source: 'jurica',
-                environment,
-              },
-            )
-          : await connectorConfig.fetchDecisionsToPseudonymiseBetween({
+            {
               startDate: new Date(dateBuilder.daysAgo(days)),
               endDate: new Date(),
               source: 'jurica',
               environment,
-            })) ?? [];
+            },
+          )
+          : await connectorConfig.fetchDecisionsToPseudonymiseBetween({
+            startDate: new Date(dateBuilder.daysAgo(days)),
+            endDate: new Date(),
+            source: 'jurica',
+            environment,
+          })) ?? [];
       logger.log({
         operationName: 'importDocumentsSince',
         msg: `${newJuricaCourtDecisions.length} ${connectorConfig.name} court decisions fetched from jurica!`,
@@ -456,19 +451,19 @@ function buildConnector(connectorConfig: connectorConfigType) {
       const newJuritjCourtDecisions =
         (byDateCreation
           ? await connectorConfig.fetchDecisionsToPseudonymiseBetweenDateCreation(
-              {
-                startDate: new Date(dateBuilder.daysAgo(days)),
-                endDate: new Date(),
-                source: 'juritj',
-                environment,
-              },
-            )
-          : await connectorConfig.fetchDecisionsToPseudonymiseBetween({
+            {
               startDate: new Date(dateBuilder.daysAgo(days)),
               endDate: new Date(),
               source: 'juritj',
               environment,
-            })) ?? [];
+            },
+          )
+          : await connectorConfig.fetchDecisionsToPseudonymiseBetween({
+            startDate: new Date(dateBuilder.daysAgo(days)),
+            endDate: new Date(),
+            source: 'juritj',
+            environment,
+          })) ?? [];
       logger.log({
         operationName: 'importDocumentsSince',
         msg: `${newJuritjCourtDecisions.length} ${connectorConfig.name} court decisions fetched from juritj!`,
@@ -615,7 +610,7 @@ function buildConnector(connectorConfig: connectorConfigType) {
       documents.push(
         await connectorConfig.mapCourtDecisionToDocument(
           courtDecision,
-          'manual',
+          'recent',
         ),
       );
     }

--- a/packages/generic/backend/src/lib/connector/buildConnector.ts
+++ b/packages/generic/backend/src/lib/connector/buildConnector.ts
@@ -93,8 +93,9 @@ function buildConnector(connectorConfig: connectorConfigType) {
 
       logger.log({
         operationName: 'importSpecificDocument',
-        msg: `Court decision found. labelStatus: ${courtDecision.labelStatus
-          }, ${!!courtDecision.pseudoText ? 'already' : 'never'} pseudonymised`,
+        msg: `Court decision found. labelStatus: ${
+          courtDecision.labelStatus
+        }, ${!!courtDecision.pseudoText ? 'already' : 'never'} pseudonymised`,
       });
       const document = await connectorConfig.mapCourtDecisionToDocument(
         courtDecision,
@@ -149,8 +150,9 @@ function buildConnector(connectorConfig: connectorConfigType) {
     const MAX_STEP = 300;
     logger.log({
       operationName: 'importNewDocuments',
-      msg: `START: ${documentsCount} - ${sources?.join('/') ?? 'all sources'
-        } - ${daysStep || DEFAULT_DAYS_STEP}`,
+      msg: `START: ${documentsCount} - ${
+        sources?.join('/') ?? 'all sources'
+      } - ${daysStep || DEFAULT_DAYS_STEP}`,
     });
 
     if (threshold) {
@@ -220,12 +222,13 @@ function buildConnector(connectorConfig: connectorConfigType) {
 
         logger.log({
           operationName: 'importNewDocuments',
-          msg: `${newCourtDecisions.length} ${connectorConfig.name
-            } court decisions fetched between ${timeOperator.convertTimestampToReadableDate(
-              startDate.getTime(),
-            )} and ${timeOperator.convertTimestampToReadableDate(
-              endDate.getTime(),
-            )}!`,
+          msg: `${newCourtDecisions.length} ${
+            connectorConfig.name
+          } court decisions fetched between ${timeOperator.convertTimestampToReadableDate(
+            startDate.getTime(),
+          )} and ${timeOperator.convertTimestampToReadableDate(
+            endDate.getTime(),
+          )}!`,
         });
         for (const courtDecision of newCourtDecisions) {
           newDocuments.push(
@@ -280,8 +283,9 @@ function buildConnector(connectorConfig: connectorConfigType) {
     const MAX_STEP = 300;
     logger.log({
       operationName: 'importNewDocuments',
-      msg: `importChainedDocuments: ${documentCount} - ${daysStep || DEFAULT_DAYS_STEP
-        }`,
+      msg: `importChainedDocuments: ${documentCount} - ${
+        daysStep || DEFAULT_DAYS_STEP
+      }`,
     });
 
     logger.log({
@@ -308,12 +312,13 @@ function buildConnector(connectorConfig: connectorConfigType) {
           )) ?? [];
         logger.log({
           operationName: 'importChainedDocuments',
-          msg: `${newCourtDecisions.length} ${connectorConfig.name
-            } court decisions fetched between ${timeOperator.convertTimestampToReadableDate(
-              startDate.getTime(),
-            )} and ${timeOperator.convertTimestampToReadableDate(
-              endDate.getTime(),
-            )}!`,
+          msg: `${newCourtDecisions.length} ${
+            connectorConfig.name
+          } court decisions fetched between ${timeOperator.convertTimestampToReadableDate(
+            startDate.getTime(),
+          )} and ${timeOperator.convertTimestampToReadableDate(
+            endDate.getTime(),
+          )}!`,
         });
         for (const courtDecision of newCourtDecisions) {
           newDocuments.push(
@@ -385,19 +390,19 @@ function buildConnector(connectorConfig: connectorConfigType) {
       const newJurinetCourtDecisions =
         (byDateCreation
           ? await connectorConfig.fetchDecisionsToPseudonymiseBetweenDateCreation(
-            {
+              {
+                startDate: new Date(dateBuilder.daysAgo(days)),
+                endDate: new Date(),
+                source: 'jurinet',
+                environment,
+              },
+            )
+          : await connectorConfig.fetchDecisionsToPseudonymiseBetween({
               startDate: new Date(dateBuilder.daysAgo(days)),
               endDate: new Date(),
               source: 'jurinet',
               environment,
-            },
-          )
-          : await connectorConfig.fetchDecisionsToPseudonymiseBetween({
-            startDate: new Date(dateBuilder.daysAgo(days)),
-            endDate: new Date(),
-            source: 'jurinet',
-            environment,
-          })) ?? [];
+            })) ?? [];
       logger.log({
         operationName: 'importDocumentsSince',
         msg: `${newJurinetCourtDecisions.length} ${connectorConfig.name} court decisions fetched from jurinet!`,
@@ -418,19 +423,19 @@ function buildConnector(connectorConfig: connectorConfigType) {
       const newJuricaCourtDecisions =
         (byDateCreation
           ? await connectorConfig.fetchDecisionsToPseudonymiseBetweenDateCreation(
-            {
+              {
+                startDate: new Date(dateBuilder.daysAgo(days)),
+                endDate: new Date(),
+                source: 'jurica',
+                environment,
+              },
+            )
+          : await connectorConfig.fetchDecisionsToPseudonymiseBetween({
               startDate: new Date(dateBuilder.daysAgo(days)),
               endDate: new Date(),
               source: 'jurica',
               environment,
-            },
-          )
-          : await connectorConfig.fetchDecisionsToPseudonymiseBetween({
-            startDate: new Date(dateBuilder.daysAgo(days)),
-            endDate: new Date(),
-            source: 'jurica',
-            environment,
-          })) ?? [];
+            })) ?? [];
       logger.log({
         operationName: 'importDocumentsSince',
         msg: `${newJuricaCourtDecisions.length} ${connectorConfig.name} court decisions fetched from jurica!`,
@@ -451,19 +456,19 @@ function buildConnector(connectorConfig: connectorConfigType) {
       const newJuritjCourtDecisions =
         (byDateCreation
           ? await connectorConfig.fetchDecisionsToPseudonymiseBetweenDateCreation(
-            {
+              {
+                startDate: new Date(dateBuilder.daysAgo(days)),
+                endDate: new Date(),
+                source: 'juritj',
+                environment,
+              },
+            )
+          : await connectorConfig.fetchDecisionsToPseudonymiseBetween({
               startDate: new Date(dateBuilder.daysAgo(days)),
               endDate: new Date(),
               source: 'juritj',
               environment,
-            },
-          )
-          : await connectorConfig.fetchDecisionsToPseudonymiseBetween({
-            startDate: new Date(dateBuilder.daysAgo(days)),
-            endDate: new Date(),
-            source: 'juritj',
-            environment,
-          })) ?? [];
+            })) ?? [];
       logger.log({
         operationName: 'importDocumentsSince',
         msg: `${newJuritjCourtDecisions.length} ${connectorConfig.name} court decisions fetched from juritj!`,

--- a/packages/generic/backend/src/modules/document/service/documentService/fetchDocumentWithoutAnnotationsNotIn.spec.ts
+++ b/packages/generic/backend/src/modules/document/service/documentService/fetchDocumentWithoutAnnotationsNotIn.spec.ts
@@ -8,28 +8,59 @@ describe('fetchDocumentWithoutAnnotationsNotIn', () => {
   const documentRepository = buildDocumentRepository();
   const treatmentRepository = buildTreatmentRepository();
 
-  it('should fetch all the documents without annotation report', async () => {
-    const documentsWithTreatments = range(5).map(() =>
-      documentModule.generator.generate(),
-    );
-    const documentWithoutTreatments = documentModule.generator.generate({
+  it('should fetch all the to annotate in priority order', async () => {
+
+    const documentPriority4 = documentModule.generator.generate({
       priority: 4,
       status: 'loaded',
     });
-    const treatments = documentsWithTreatments.map((document) =>
-      treatmentModule.generator.generate({ documentId: document._id }),
-    );
-    await Promise.all(
-      [...documentsWithTreatments, documentWithoutTreatments].map(
-        documentRepository.insert,
-      ),
-    );
-    await Promise.all(treatments.map(treatmentRepository.insert));
+    const documentPriority3 = documentModule.generator.generate({
+      priority: 3,
+      status: 'loaded',
+    });
+    const documentPriority2 = documentModule.generator.generate({
+      priority: 2,
+      status: 'loaded',
+    });
+    const documentPriority1 = documentModule.generator.generate({
+      priority: 1,
+      status: 'loaded',
+    });
+    const documentPriority0 = documentModule.generator.generate({
+      priority: 0,
+      status: 'loaded',
+    });
 
-    const documentWithoutAnnotations = await fetchDocumentWithoutAnnotationsNotIn(
-      [],
-    );
+    documentRepository.insert(documentPriority0)
+    documentRepository.insert(documentPriority1)
+    documentRepository.insert(documentPriority2)
+    documentRepository.insert(documentPriority3)
+    documentRepository.insert(documentPriority4)
 
-    expect(documentWithoutAnnotations).toEqual(documentWithoutTreatments);
+    expect(await fetchDocumentWithoutAnnotationsNotIn([])).toEqual(documentPriority4);
+
+    expect(await fetchDocumentWithoutAnnotationsNotIn([
+      documentPriority4._id,
+    ]))
+      .toEqual(documentPriority3);
+
+    expect(await fetchDocumentWithoutAnnotationsNotIn([
+      documentPriority4._id,
+      documentPriority3._id,
+    ]))
+      .toEqual(documentPriority2);
+
+    expect(await fetchDocumentWithoutAnnotationsNotIn([
+      documentPriority4._id,
+      documentPriority3._id,
+      documentPriority2._id,
+    ])).toEqual(documentPriority1);
+
+    expect(await fetchDocumentWithoutAnnotationsNotIn([
+      documentPriority4._id,
+      documentPriority3._id,
+      documentPriority2._id,
+      documentPriority1._id,
+    ])).toEqual(documentPriority0);
   });
 });

--- a/packages/generic/backend/src/modules/document/service/documentService/fetchDocumentWithoutAnnotationsNotIn.spec.ts
+++ b/packages/generic/backend/src/modules/document/service/documentService/fetchDocumentWithoutAnnotationsNotIn.spec.ts
@@ -1,15 +1,11 @@
-import { range } from 'lodash';
-import { documentModule, treatmentModule } from '@label/core';
+import { documentModule } from '@label/core';
 import { fetchDocumentWithoutAnnotationsNotIn } from './fetchDocumentWithoutAnnotationsNotIn';
-import { buildTreatmentRepository } from '../../../treatment/repository';
 import { buildDocumentRepository } from '../../repository';
 
 describe('fetchDocumentWithoutAnnotationsNotIn', () => {
   const documentRepository = buildDocumentRepository();
-  const treatmentRepository = buildTreatmentRepository();
 
   it('should fetch all the to annotate in priority order', async () => {
-
     const documentPriority4 = documentModule.generator.generate({
       priority: 4,
       status: 'loaded',
@@ -31,36 +27,42 @@ describe('fetchDocumentWithoutAnnotationsNotIn', () => {
       status: 'loaded',
     });
 
-    documentRepository.insert(documentPriority0)
-    documentRepository.insert(documentPriority1)
-    documentRepository.insert(documentPriority2)
-    documentRepository.insert(documentPriority3)
-    documentRepository.insert(documentPriority4)
+    documentRepository.insert(documentPriority0);
+    documentRepository.insert(documentPriority1);
+    documentRepository.insert(documentPriority2);
+    documentRepository.insert(documentPriority3);
+    documentRepository.insert(documentPriority4);
 
-    expect(await fetchDocumentWithoutAnnotationsNotIn([])).toEqual(documentPriority4);
+    expect(await fetchDocumentWithoutAnnotationsNotIn([])).toEqual(
+      documentPriority4,
+    );
 
-    expect(await fetchDocumentWithoutAnnotationsNotIn([
-      documentPriority4._id,
-    ]))
-      .toEqual(documentPriority3);
+    expect(
+      await fetchDocumentWithoutAnnotationsNotIn([documentPriority4._id]),
+    ).toEqual(documentPriority3);
 
-    expect(await fetchDocumentWithoutAnnotationsNotIn([
-      documentPriority4._id,
-      documentPriority3._id,
-    ]))
-      .toEqual(documentPriority2);
+    expect(
+      await fetchDocumentWithoutAnnotationsNotIn([
+        documentPriority4._id,
+        documentPriority3._id,
+      ]),
+    ).toEqual(documentPriority2);
 
-    expect(await fetchDocumentWithoutAnnotationsNotIn([
-      documentPriority4._id,
-      documentPriority3._id,
-      documentPriority2._id,
-    ])).toEqual(documentPriority1);
+    expect(
+      await fetchDocumentWithoutAnnotationsNotIn([
+        documentPriority4._id,
+        documentPriority3._id,
+        documentPriority2._id,
+      ]),
+    ).toEqual(documentPriority1);
 
-    expect(await fetchDocumentWithoutAnnotationsNotIn([
-      documentPriority4._id,
-      documentPriority3._id,
-      documentPriority2._id,
-      documentPriority1._id,
-    ])).toEqual(documentPriority0);
+    expect(
+      await fetchDocumentWithoutAnnotationsNotIn([
+        documentPriority4._id,
+        documentPriority3._id,
+        documentPriority2._id,
+        documentPriority1._id,
+      ]),
+    ).toEqual(documentPriority0);
   });
 });

--- a/packages/generic/backend/src/modules/document/service/documentService/fetchDocumentWithoutAnnotationsNotIn.ts
+++ b/packages/generic/backend/src/modules/document/service/documentService/fetchDocumentWithoutAnnotationsNotIn.ts
@@ -12,24 +12,17 @@ async function fetchDocumentWithoutAnnotationsNotIn(
   const treatedDocumentIds = await treatmentService.fetchTreatedDocumentIds();
   const idsNotToSearchIn = [...treatedDocumentIds, ...documentIdsToExclude];
   let document: documentType | undefined;
-  document = await documentRepository.findOneByStatusAndPriorityNotIn(
-    { status: 'loaded', priority: 4 },
-    idsNotToSearchIn,
-  );
-  if (document) {
-    return document;
-  }
-  document = await documentRepository.findOneByStatusAndPriorityNotIn(
-    { status: 'loaded', priority: 2 },
-    idsNotToSearchIn,
-  );
-  if (document) {
-    return document;
-  }
-  document = await documentRepository.findOneByStatusAndPriorityNotIn(
-    { status: 'loaded', priority: 0 },
-    idsNotToSearchIn,
-  );
 
-  return document;
+  const priorities = [4, 3, 2, 1, 0];
+
+  for (const priority of priorities) {
+    document = await documentRepository.findOneByStatusAndPriorityNotIn(
+      { status: 'loaded', priority },
+      idsNotToSearchIn
+    );
+    if (document) {
+      return document;
+    }
+  }
+  return undefined;
 }

--- a/packages/generic/backend/src/modules/document/service/documentService/fetchDocumentWithoutAnnotationsNotIn.ts
+++ b/packages/generic/backend/src/modules/document/service/documentService/fetchDocumentWithoutAnnotationsNotIn.ts
@@ -18,7 +18,7 @@ async function fetchDocumentWithoutAnnotationsNotIn(
   for (const priority of priorities) {
     document = await documentRepository.findOneByStatusAndPriorityNotIn(
       { status: 'loaded', priority },
-      idsNotToSearchIn
+      idsNotToSearchIn,
     );
     if (document) {
       return document;


### PR DESCRIPTION
## Issue description :
Documents with priority 3 and 1 where not send to the NLP api when annotating all the documents

## Describe your changes :
* update the document to annotate fetcher to include priorities from 4 to 0
* correct and update the corresponding test
* change the priority for manual imports

## How to test :
* import severals documents with this command : `docker container exec -it label_backend_1 sh -c "cd packages/courDeCassation; sh scripts/runLocalScript.sh ./dist/scripts/importSpecificDocumentFromSder.js --documentNumber=XXX --source=XXX"` with `documentNumber` and `source` matching your `storage` documents and annotation
* Shuffle their priority in database between 0 to 4
* annotate documents with this command : `docker container exec -it label_backend_1 sh -c "cd packages/courDeCassation; sh scripts/runLocalScript.sh ./dist/scripts/annotateDocumentsWithoutAnnotationsWithNlp.js"`
* Check that they are correctly annotated and annotated by priorities

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] The feature works locally.
- [x] If it's relevant I added tests.
- ~~[ ] Will this be part of a product update? If yes, please write one phrase about this update.~~
