### PR TITLE
adding route default for jurica && endCaseCode NACCode in statistics collection : labelDB

### DIFF
--- a/packages/courDeCassation/src/connector/mapper/extractors/extractRoute/extractRoute.spec.ts
+++ b/packages/courDeCassation/src/connector/mapper/extractors/extractRoute/extractRoute.spec.ts
@@ -124,7 +124,6 @@ describe('extractRoute', () => {
       'jurica',
     );
 
-    //expect(route).toBe('exhaustive');
     expect(route).toBe('default');
   });
 

--- a/packages/courDeCassation/src/connector/mapper/extractors/extractRoute/extractRoute.spec.ts
+++ b/packages/courDeCassation/src/connector/mapper/extractors/extractRoute/extractRoute.spec.ts
@@ -22,7 +22,7 @@ describe('extractRoute', () => {
     expect(route).toBe('exhaustive');
   });
 
-  it('should return exhaustive if no endCaseCode & no NACCode', async () => {
+  it('should return default if no endCaseCode & no NACCode', async () => {
     const route = extractRoute(
       {
         additionalTermsToAnnotate: '',
@@ -40,7 +40,7 @@ describe('extractRoute', () => {
       'jurica',
     );
 
-    expect(route).toBe('exhaustive');
+    expect(route).toBe('default');
   });
 
   it('should return exhaustive if jurica with endCaseCode 44E & NACCode 10A', async () => {
@@ -106,7 +106,7 @@ describe('extractRoute', () => {
     expect(route).toBe('simple');
   });
 
-  it('should return exhaustive if jurica with endCaseCode 33G (not in csv)', async () => {
+  it('should return default if jurica with endCaseCode 33G (not in csv)', async () => {
     const route = extractRoute(
       {
         additionalTermsToAnnotate: '',
@@ -124,7 +124,8 @@ describe('extractRoute', () => {
       'jurica',
     );
 
-    expect(route).toBe('exhaustive');
+    //expect(route).toBe('exhaustive');
+    expect(route).toBe('default');
   });
 
   it('should return automatic if NA', async () => {

--- a/packages/courDeCassation/src/connector/mapper/extractors/extractRoute/extractRouteForJurica.ts
+++ b/packages/courDeCassation/src/connector/mapper/extractors/extractRoute/extractRouteForJurica.ts
@@ -22,7 +22,6 @@ function extractRouteForJurica({
   const decEndCaseCode: number = transformLetterCodeToDec({
     code: endCaseCode,
   });
-
   // Les codes de fin d'affaire 11A à 22X inclus + 33A à 33C priment sur les codes NAC
   // Les codes NAC priment sur les codes de fin d'affaire à partir du code de fin d'affaire 33D
   if (
@@ -32,7 +31,9 @@ function extractRouteForJurica({
     const endCaseCodeCsv = fs.readFileSync('./static/endCaseRoutes.csv', {
       encoding: 'utf8',
     }) as string;
+
     const endCaseCodeData = {} as Array<any>;
+
     endCaseCodeCsv.split('\n').forEach((line) => {
       const l = line.split(',');
       if (l[1]) {
@@ -50,7 +51,9 @@ function extractRouteForJurica({
   const NACCodeCsv = fs.readFileSync('./static/NACCodeRoutes.csv', {
     encoding: 'utf8',
   }) as string;
+
   const NACCodeData = {} as Array<any>;
+
   NACCodeCsv.split('\n').forEach((line) => {
     const l = line.split(',');
     if (l[1]) {
@@ -63,6 +66,6 @@ function extractRouteForJurica({
   return (
     (NACCodeData[
       transformLetterCodeToDec({ code: NACCode })
-    ] as documentType['route']) ?? 'exhaustive'
+    ] as documentType['route']) ?? 'default'
   );
 }

--- a/packages/generic/core/src/modules/statistic/generator/statisticGenerator.ts
+++ b/packages/generic/core/src/modules/statistic/generator/statisticGenerator.ts
@@ -26,6 +26,8 @@ const statisticGenerator: generatorType<statisticType> = {
     treatmentDate,
     treatmentsSummary,
     wordsCount,
+    endCaseCode,
+    NACCode
   } = {}) => ({
     _id: _id ? idModule.lib.buildId(_id) : idModule.lib.buildId(),
     annotationsCount: annotationsCount ? annotationsCount : 0,
@@ -38,6 +40,8 @@ const statisticGenerator: generatorType<statisticType> = {
     linkedEntitiesCount: linkedEntitiesCount ? linkedEntitiesCount : 0,
     publicationCategory: publicationCategory ? publicationCategory : [],
     session: session || undefined,
+    endCaseCode: endCaseCode || undefined,
+    NACCode: NACCode || undefined,
     route: route ?? `default`,
     importer: importer ?? `default`,
     source: source ?? `SOURCE_${Math.random()}`,

--- a/packages/generic/core/src/modules/statistic/generator/statisticGenerator.ts
+++ b/packages/generic/core/src/modules/statistic/generator/statisticGenerator.ts
@@ -27,7 +27,7 @@ const statisticGenerator: generatorType<statisticType> = {
     treatmentsSummary,
     wordsCount,
     endCaseCode,
-    NACCode
+    NACCode,
   } = {}) => ({
     _id: _id ? idModule.lib.buildId(_id) : idModule.lib.buildId(),
     annotationsCount: annotationsCount ? annotationsCount : 0,

--- a/packages/generic/core/src/modules/statistic/lib/buildStatistic.ts
+++ b/packages/generic/core/src/modules/statistic/lib/buildStatistic.ts
@@ -35,6 +35,8 @@ function buildStatistic({
       : undefined,
     linkedEntitiesCount,
     session: document.decisionMetadata.session || undefined,
+    endCaseCode: document.decisionMetadata.endCaseCode || undefined,
+    NACCode: document.decisionMetadata.NACCode || undefined,
     publicationCategory: document.publicationCategory,
     route: document.route,
     importer: document.importer,

--- a/packages/generic/core/src/modules/statistic/statisticType.ts
+++ b/packages/generic/core/src/modules/statistic/statisticType.ts
@@ -45,6 +45,20 @@ const statisticModel = buildModel({
         { kind: 'primitive', content: 'undefined' },
       ],
     },
+    endCaseCode: {
+      kind: 'or',
+      content: [
+        { kind: 'primitive', content: 'string' },
+        { kind: 'primitive', content: 'undefined' },
+      ],
+    },
+    NACCode: {
+      kind: 'or',
+      content: [
+        { kind: 'primitive', content: 'string' },
+        { kind: 'primitive', content: 'undefined' },
+      ],
+    },
     route: documentModel.content.route,
     source: { kind: 'primitive', content: 'string' },
     surAnnotationsCount: {


### PR DESCRIPTION
## Issue description 

- Add default route for jurica decuments

## Describe your changes :

- Change from 'exhaustive' to 'default' in extractRouteForJurica.ts line 69.
- Addition of the fields 'endCaseCode' and 'NACCode' in the statisticType => core.
- Adjustment of the tests: extactRoute.spec.ts.

## How to test :

- cd label/packages/courDeCassation/src/connector/mapper/extractors/extractRoute
- Run yarn test extractRoute.spec.ts
## Checklist before requesting a review
- [x] I have performed a self-review of my code. Good
- [x] The feature works locally.
- [x] If it's relevant I added tests.
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
