### PR TITLE
receive new type instead of new categories to omit

### DIFF
--- a/packages/courDeCassation/src/annotator/fetcher/api/nlpApiType.ts
+++ b/packages/courDeCassation/src/annotator/fetcher/api/nlpApiType.ts
@@ -17,8 +17,8 @@ type nlpApiType = {
 type nlpResponseType = {
   entities: nlpAnnotationType[];
   checklist: string[];
-  categoriesToAnnotate?: string[];
-  categoriesToUnAnnotate?: string[];
+  newCategoriesToAnnotate?: string[];
+  newCategoriesToUnAnnotate?: string[];
   additionalTermsToAnnotate?: string[];
   additionalTermsToUnAnnotate?: string[];
   additionalTermsParsingFailed?: boolean;

--- a/packages/courDeCassation/src/annotator/fetcher/api/nlpApiType.ts
+++ b/packages/courDeCassation/src/annotator/fetcher/api/nlpApiType.ts
@@ -17,7 +17,8 @@ type nlpApiType = {
 type nlpResponseType = {
   entities: nlpAnnotationType[];
   checklist: string[];
-  newCategoriesToOmit?: string[];
+  categoriesToAnnotate?: string[];
+  categoriesToUnAnnotate?: string[];
   additionalTermsToAnnotate?: string[];
   additionalTermsToUnAnnotate?: string[];
   additionalTermsParsingFailed?: boolean;

--- a/packages/courDeCassation/src/annotator/fetcher/api/nlpLocalApi.ts
+++ b/packages/courDeCassation/src/annotator/fetcher/api/nlpLocalApi.ts
@@ -39,8 +39,8 @@ function buildNlpLocalApi(): nlpApiType {
           availableCategories.includes(entity.label),
         ),
         checklist: annotations.checklist,
-        categoriesToAnnotate: annotations.categoriesToAnnotate,
-        categoriesToUnAnnotate: annotations.categoriesToUnAnnotate,
+        newCategoriesToAnnotate: annotations.newCategoriesToAnnotate,
+        newCategoriesToUnAnnotate: annotations.newCategoriesToUnAnnotate,
         additionalTermsToAnnotate: annotations.additionalTermsToAnnotate,
         additionalTermsToUnAnnotate: annotations.additionalTermsToUnAnnotate,
       };

--- a/packages/courDeCassation/src/annotator/fetcher/api/nlpLocalApi.ts
+++ b/packages/courDeCassation/src/annotator/fetcher/api/nlpLocalApi.ts
@@ -39,7 +39,8 @@ function buildNlpLocalApi(): nlpApiType {
           availableCategories.includes(entity.label),
         ),
         checklist: annotations.checklist,
-        newCategoriesToOmit: annotations.newCategoriesToOmit,
+        categoriesToAnnotate: annotations.categoriesToAnnotate,
+        categoriesToUnAnnotate: annotations.categoriesToUnAnnotate,
         additionalTermsToAnnotate: annotations.additionalTermsToAnnotate,
         additionalTermsToUnAnnotate: annotations.additionalTermsToUnAnnotate,
       };

--- a/packages/courDeCassation/src/annotator/fetcher/nlpFetcher.ts
+++ b/packages/courDeCassation/src/annotator/fetcher/nlpFetcher.ts
@@ -25,7 +25,8 @@ function buildNlpFetcher(nlpApiBaseUrl: string) {
         ),
         documentId: document._id,
         report: nlpMapper.mapNlpAnnotationstoReport(nlpAnnotations, document),
-        newCategoriesToOmit: nlpAnnotations.newCategoriesToOmit,
+        categoriesToAnnotate: nlpAnnotations.categoriesToAnnotate,
+        categoriesToUnAnnotate: nlpAnnotations.categoriesToUnAnnotate,
         computedAdditionalTerms: nlpMapper.mapNlpAdditionalTerms(
           nlpAnnotations,
         ),

--- a/packages/courDeCassation/src/annotator/fetcher/nlpFetcher.ts
+++ b/packages/courDeCassation/src/annotator/fetcher/nlpFetcher.ts
@@ -25,8 +25,8 @@ function buildNlpFetcher(nlpApiBaseUrl: string) {
         ),
         documentId: document._id,
         report: nlpMapper.mapNlpAnnotationstoReport(nlpAnnotations, document),
-        categoriesToAnnotate: nlpAnnotations.categoriesToAnnotate,
-        categoriesToUnAnnotate: nlpAnnotations.categoriesToUnAnnotate,
+        newCategoriesToAnnotate: nlpAnnotations.newCategoriesToAnnotate,
+        newCategoriesToUnAnnotate: nlpAnnotations.newCategoriesToUnAnnotate,
         computedAdditionalTerms: nlpMapper.mapNlpAdditionalTerms(
           nlpAnnotations,
         ),

--- a/packages/generic/backend/src/lib/annotator/annotatorConfigType.ts
+++ b/packages/generic/backend/src/lib/annotator/annotatorConfigType.ts
@@ -18,8 +18,8 @@ type annotatorConfigType = {
     annotations: annotationType[];
     documentId: idType;
     report: annotationReportType;
-    categoriesToAnnotate?: string[];
-    categoriesToUnAnnotate?: string[];
+    newCategoriesToAnnotate?: string[];
+    newCategoriesToUnAnnotate?: string[];
     computedAdditionalTerms?: documentType['decisionMetadata']['computedAdditionalTerms'];
     additionalTermsParsingFailed?: boolean;
   }>;

--- a/packages/generic/backend/src/lib/annotator/annotatorConfigType.ts
+++ b/packages/generic/backend/src/lib/annotator/annotatorConfigType.ts
@@ -18,7 +18,8 @@ type annotatorConfigType = {
     annotations: annotationType[];
     documentId: idType;
     report: annotationReportType;
-    newCategoriesToOmit?: documentType['decisionMetadata']['categoriesToOmit'];
+    categoriesToAnnotate?: string[];
+    categoriesToUnAnnotate?: string[];
     computedAdditionalTerms?: documentType['decisionMetadata']['computedAdditionalTerms'];
     additionalTermsParsingFailed?: boolean;
   }>;

--- a/packages/generic/backend/src/lib/annotator/buildAnnotator.ts
+++ b/packages/generic/backend/src/lib/annotator/buildAnnotator.ts
@@ -180,8 +180,8 @@ function buildAnnotator(
       annotations,
       documentId,
       report,
-      categoriesToAnnotate,
-      categoriesToUnAnnotate,
+      newCategoriesToAnnotate,
+      newCategoriesToUnAnnotate,
       computedAdditionalTerms,
       additionalTermsParsingFailed,
     } = await annotatorConfig.fetchAnnotationOfDocument(settings, document);
@@ -226,23 +226,23 @@ function buildAnnotator(
     }
 
     let newCategoriesToOmit = document.decisionMetadata.categoriesToOmit;
-    if (!!categoriesToUnAnnotate) {
+    if (!!newCategoriesToUnAnnotate) {
       logger.log({
         operationName: 'annotateDocument',
-        msg: `categoriesToUnAnnotate found, adding '${categoriesToUnAnnotate}' to categoriesToOmit if not already in`,
+        msg: `categoriesToUnAnnotate found, adding '${newCategoriesToUnAnnotate}' to categoriesToOmit if not already in`,
       });
       newCategoriesToOmit = Array.from(
-        new Set(newCategoriesToOmit.concat(categoriesToUnAnnotate)),
+        new Set(newCategoriesToOmit.concat(newCategoriesToUnAnnotate)),
       );
     }
 
-    if (!!categoriesToAnnotate) {
+    if (!!newCategoriesToAnnotate) {
       logger.log({
         operationName: 'annotateDocument',
-        msg: `categoriesToAnnotate found, removing '${categoriesToAnnotate}' from categoriesToOmit if present`,
+        msg: `categoriesToAnnotate found, removing '${newCategoriesToAnnotate}' from categoriesToOmit if present`,
       });
       newCategoriesToOmit = newCategoriesToOmit.filter(
-        (category) => !categoriesToAnnotate.includes(category),
+        (category) => !newCategoriesToAnnotate.includes(category),
       );
     }
 


### PR DESCRIPTION
## Issue description :
To manage correctly categoriesToOmit update nlp api will return `categoriesToAnnotate` et `categoriesToUnanotate` instead of `newCategoriesToOmit`

## Describe your changes :

## How to test :
In storage annotation add something like that : 
```
  "categoriesToAnnotate": [
    "adresse",
    "numeroSiretSiren"
  ],
  "categoriesToUnAnnotate": [
    "etablissement",
    "plaqueImmatriculation"
  ]
```

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] The feature works locally.
- [x] If it's relevant I added tests.
- [ ] ~~Will this be part of a product update? If yes, please write one phrase about this update.~~
