### PR TITLE
fixing replacement terms re-rending in annotator view when annote

### DIFF
--- a/packages/generic/client/src/pages/Home/DocumentAnnotator/DocumentPanel/DocumentAnnotationText.tsx
+++ b/packages/generic/client/src/pages/Home/DocumentAnnotator/DocumentPanel/DocumentAnnotationText.tsx
@@ -15,6 +15,7 @@ type propsType = { annotation: annotationType; anonymizer: clientAnonymizerType 
 
 class PureDocumentAnnotationText extends React.PureComponent<propsType> {
 
+
   render() {
     return <DocumentAnnotationText annotation={this.props.annotation} anonymizer={this.props.anonymizer} />;
   }

--- a/packages/generic/client/src/pages/Home/DocumentAnnotator/DocumentPanel/DocumentAnnotationText.tsx
+++ b/packages/generic/client/src/pages/Home/DocumentAnnotator/DocumentPanel/DocumentAnnotationText.tsx
@@ -13,15 +13,7 @@ export { PureDocumentAnnotationText as DocumentAnnotationText };
 
 type propsType = { annotation: annotationType; anonymizer: clientAnonymizerType };
 
-class PureDocumentAnnotationText extends React.Component<propsType> {
-  shouldComponentUpdate(nextProps: propsType) {
-    return (
-      nextProps.annotation.category !== this.props.annotation.category ||
-      nextProps.annotation.entityId !== this.props.annotation.entityId ||
-      nextProps.annotation.start !== this.props.annotation.start ||
-      nextProps.annotation.text !== this.props.annotation.text
-    );
-  }
+class PureDocumentAnnotationText extends React.PureComponent<propsType> {
 
   render() {
     return <DocumentAnnotationText annotation={this.props.annotation} anonymizer={this.props.anonymizer} />;

--- a/packages/generic/client/src/pages/Home/DocumentAnnotator/DocumentPanel/DocumentAnnotationText.tsx
+++ b/packages/generic/client/src/pages/Home/DocumentAnnotator/DocumentPanel/DocumentAnnotationText.tsx
@@ -14,8 +14,6 @@ export { PureDocumentAnnotationText as DocumentAnnotationText };
 type propsType = { annotation: annotationType; anonymizer: clientAnonymizerType };
 
 class PureDocumentAnnotationText extends React.PureComponent<propsType> {
-
-
   render() {
     return <DocumentAnnotationText annotation={this.props.annotation} anonymizer={this.props.anonymizer} />;
   }


### PR DESCRIPTION
## Issue description :

- Replacement term  (re-rendering with shouldComponentUpdate lifecycle)

## Describe your changes :

- I removed the shouldComponentUpdate lifecycle and changed the PureDocumentAnnotationText class... to extend React.PureComponent instead of React.Component.

## How to test :

- Run the project, annote a document like annotator and handle the annonymisor text tool button

## Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [x] The feature works locally.
- [ ] If it's relevant I added tests.
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

- This update will refresh the re-render when annotator will add an annotation.
