### PR TITLE
fetch TCOM decisions

### DIFF
--- a/packages/courDeCassation/src/connector/fetcher/sderFetcher.ts
+++ b/packages/courDeCassation/src/connector/fetcher/sderFetcher.ts
@@ -23,7 +23,7 @@ const sderFetcher = {
   }: {
     startDate: Date;
     endDate: Date;
-    source: 'jurinet' | 'jurica' | 'juritj';
+    source: string;
   }) {
     const courtDecisions = await sderApi.fetchDecisionsToPseudonymiseBetween({
       startDate,
@@ -46,7 +46,7 @@ const sderFetcher = {
   }: {
     startDate: Date;
     endDate: Date;
-    source: 'jurinet' | 'jurica' | 'juritj';
+    source: string;
   }) {
     const courtDecisions = await sderApi.fetchDecisionsToPseudonymiseBetweenDateCreation(
       {

--- a/packages/courDeCassation/src/connector/mapper/mapCourtDecisionToDocument.ts
+++ b/packages/courDeCassation/src/connector/mapper/mapCourtDecisionToDocument.ts
@@ -67,6 +67,7 @@ async function mapCourtDecisionToDocument(
   const NAOCode = sderCourtDecision.NAOCode || '';
   const endCaseCode = sderCourtDecision.endCaseCode || '';
 
+  // TODO add title compute for TCOM
   const title = computeTitleFromParsedCourtDecision({
     source: source,
     number: sderCourtDecision.sourceId,

--- a/packages/courDeCassation/src/sderApi/sderApiType.ts
+++ b/packages/courDeCassation/src/sderApi/sderApiType.ts
@@ -15,12 +15,12 @@ type sderApiType = {
   fetchDecisionsToPseudonymiseBetween: (param: {
     startDate: Date;
     endDate: Date;
-    source: 'jurinet' | 'jurica' | 'juritj';
+    source: string;
   }) => Promise<Array<decisionType>>;
   fetchDecisionsToPseudonymiseBetweenDateCreation: (param: {
     startDate: Date;
     endDate: Date;
-    source: 'jurinet' | 'jurica' | 'juritj';
+    source: string;
   }) => Promise<Array<decisionType>>;
   fetchCourtDecisionBySourceIdAndSourceName: (param: {
     sourceId: decisionType['sourceId'];

--- a/packages/generic/backend/src/lib/connector/buildConnector.ts
+++ b/packages/generic/backend/src/lib/connector/buildConnector.ts
@@ -549,6 +549,41 @@ function buildConnector(connectorConfig: connectorConfigType) {
         data: error as Record<string, unknown>,
       });
     }
+    try {
+      logger.log({
+        operationName: 'importDocumentsSinceOrBetween',
+        msg: `Fetching ${connectorConfig.name} juritcom documents...`,
+      });
+      const newJuritcomCourtDecisions =
+        (byDateCreation
+          ? await connectorConfig.fetchDecisionsToPseudonymiseBetweenDateCreation(
+              {
+                startDate: new Date(dateBuilder.daysAgo(fromDaysAgo)),
+                endDate: toDaysAgo
+                  ? new Date(dateBuilder.daysAgo(toDaysAgo))
+                  : new Date(),
+                source: 'juritcom',
+              },
+            )
+          : await connectorConfig.fetchDecisionsToPseudonymiseBetween({
+              startDate: new Date(dateBuilder.daysAgo(fromDaysAgo)),
+              endDate: toDaysAgo
+                ? new Date(dateBuilder.daysAgo(toDaysAgo))
+                : new Date(),
+              source: 'juritcom',
+            })) ?? [];
+      logger.log({
+        operationName: 'importDocumentsSinceOrBetween',
+        msg: `${newJuritcomCourtDecisions.length} ${connectorConfig.name} court decisions fetched from juritcom!`,
+      });
+      newCourtDecisions.push(...newJuritcomCourtDecisions);
+    } catch (error) {
+      logger.error({
+        operationName: 'importDocumentsSinceOrBetween',
+        msg: 'Error',
+        data: error as Record<string, unknown>,
+      });
+    }
     const documents = [] as documentType[];
     for (const courtDecision of newCourtDecisions) {
       documents.push(

--- a/packages/generic/backend/src/lib/connector/connectorConfigType.ts
+++ b/packages/generic/backend/src/lib/connector/connectorConfigType.ts
@@ -23,12 +23,12 @@ type connectorConfigType = {
   fetchDecisionsToPseudonymiseBetween(param: {
     startDate: Date;
     endDate: Date;
-    source: 'jurinet' | 'jurica' | 'juritj';
+    source: string;
   }): Promise<decisionType[] | undefined>;
   fetchDecisionsToPseudonymiseBetweenDateCreation(param: {
     startDate: Date;
     endDate: Date;
-    source: 'jurinet' | 'jurica' | 'juritj';
+    source: string;
   }): Promise<decisionType[] | undefined>;
   updateDocumentsLoadedStatus: (param: {
     documents: documentType[];

--- a/packages/generic/client/src/pages/Admin/PreAssignDocuments/AddPreAssignationDrawer/AddPreAssignationDrawer.tsx
+++ b/packages/generic/client/src/pages/Admin/PreAssignDocuments/AddPreAssignationDrawer/AddPreAssignationDrawer.tsx
@@ -17,7 +17,7 @@ export { AddWorkingUserDrawer };
 const FIELD_WIDTH = 400;
 const DRAWER_WIDTH = 600;
 
-const sources = ['jurinet', 'jurica', 'juritj'];
+const sources = ['jurinet', 'jurica', 'juritj', 'juritcom'];
 
 type formErrorType = {
   source?: boolean;


### PR DESCRIPTION
Cette branche contient les changements permettant de recevoir les décisions de TCOM dans label sans attendre la finalisation de l'interraction entre label et l'api-dbsder 