### PR TITLE
Export checklist throw dbsderapi

### DIFF
--- a/packages/generic/backend/src/lib/connector/buildConnector.ts
+++ b/packages/generic/backend/src/lib/connector/buildConnector.ts
@@ -118,6 +118,23 @@ function buildConnector(connectorConfig: connectorConfigType) {
             },
             settings,
           );
+
+          // on récupère la checklist du treatment NLP le plus récent
+          const reimportedChecklist = courtDecision.labelTreatments
+            ?.filter((treatment) => treatment.source === 'NLP')
+            .sort((a, b) => b.order - a.order)[0].checklist;
+
+          if (reimportedChecklist) {
+            await documentService.updateDocumentChecklist(
+              document._id,
+              reimportedChecklist,
+            );
+            logger.log({
+              operationName: 'importSpecificDocument',
+              msg: 'Checklist reimported',
+            });
+          }
+
           logger.log({
             operationName: 'importSpecificDocument',
             msg: 'LabelTreatments reimported, checking for pre-assignation.',
@@ -158,7 +175,7 @@ function buildConnector(connectorConfig: connectorConfigType) {
     } catch (error) {
       logger.error({
         operationName: 'importSpecificDocument',
-        msg: 'Error',
+        msg: `${error}`,
         data: error as Record<string, unknown>,
       });
     }
@@ -221,10 +238,10 @@ function insertDocument(document: documentType) {
       },
     });
     return insertedDocument;
-  } catch {
+  } catch (error) {
     logger.error({
       operationName: 'documentInsertion',
-      msg: `Failed to import ${document.source}:${document.documentNumber} document`,
+      msg: `Failed to import ${document.source}:${document.documentNumber} document. ${error}`,
       data: {
         decision: {
           sourceId: document.documentNumber,

--- a/packages/generic/backend/src/lib/connector/buildConnector.ts
+++ b/packages/generic/backend/src/lib/connector/buildConnector.ts
@@ -72,7 +72,7 @@ function buildConnector(connectorConfig: connectorConfigType) {
       });
 
       if (lowPriority) {
-        await insertDocument({ ...document });
+        await insertDocument({ ...document, route: 'exhaustive' });
       } else {
         await insertDocument({ ...document, route: 'request', priority: 4 });
       }

--- a/packages/generic/backend/src/lib/exporter/buildExporter.spec.ts
+++ b/packages/generic/backend/src/lib/exporter/buildExporter.spec.ts
@@ -22,19 +22,34 @@ describe('buildExporter', () => {
   describe('exportTreatedDocumentsSince', () => {
     it('should export all the ready document since the given days fetched by the exporter', async () => {
       const days = 4;
+      const checklist = [
+        {
+          check_type: 'check',
+          message: 'message',
+          short_message: 'short message',
+          entities: [],
+          sentences: [],
+          metadata_text: [],
+        },
+      ];
       const documents = ([
         {
           text: 'Benoit est ingénieur',
           status: 'done',
           updateDate: dateBuilder.daysAgo(5),
+          checklist: checklist,
         },
         { status: 'pending' },
         {
           text: 'Romain est designer',
           status: 'done',
           updateDate: dateBuilder.daysAgo(7),
+          checklist: checklist,
         },
-        { status: 'done', updateDate: dateBuilder.daysAgo(2) },
+        {
+          status: 'done',
+          updateDate: dateBuilder.daysAgo(2),
+        },
       ] as const).map(documentModule.generator.generate);
       const treatments = [
         {
@@ -105,6 +120,7 @@ describe('buildExporter', () => {
           source: 'NLP',
           treatmentDate: '2024-07-12T09:28:27.000Z',
           version: undefined,
+          checklist: checklist,
         },
         {
           annotations: [
@@ -120,6 +136,7 @@ describe('buildExporter', () => {
           source: 'NLP',
           treatmentDate: '2024-07-12T09:29:59.000Z',
           version: undefined,
+          checklist: checklist,
         },
       ]);
     });

--- a/packages/generic/backend/src/lib/exporter/buildExporter.ts
+++ b/packages/generic/backend/src/lib/exporter/buildExporter.ts
@@ -197,6 +197,7 @@ function buildExporter(
         labelTreatments: treatmentModule.lib.concat(
           treatments,
           document.nlpVersions,
+          document.checklist,
         ),
       });
       logger.log({

--- a/packages/generic/backend/src/modules/document/service/documentService/updateDocumentChecklist.spec.ts
+++ b/packages/generic/backend/src/modules/document/service/documentService/updateDocumentChecklist.spec.ts
@@ -7,7 +7,7 @@ describe('updateDocumentChecklist', () => {
 
   const checklist = [
     {
-      checkType: `My checkType`,
+      check_type: `My check_type`,
       message: 'My check message',
       short_message: 'Short message',
       entities: [

--- a/packages/generic/client/src/pages/Home/DocumentAnnotator/AnnotationsPanel/useChecklistEntryHandler.ts
+++ b/packages/generic/client/src/pages/Home/DocumentAnnotator/AnnotationsPanel/useChecklistEntryHandler.ts
@@ -77,7 +77,7 @@ function useChecklistEntryHandler({
       }
     });
 
-    if (result.length === 0 && check.sentences) {
+    if (result.length === 0 && check.sentences.length > 0) {
       check.sentences.forEach((sentence) => {
         const linesWithSentence = splittedTextByLine.filter(({ content }) =>
           content.some((chunk) => {

--- a/packages/generic/core/package.json
+++ b/packages/generic/core/package.json
@@ -36,7 +36,7 @@
     "bcryptjs": "^2.4.3",
     "lodash": "^4.17.21",
     "mongodb": "^3.6.1",
-    "dbsder-api-types": "1.7.0",
+    "dbsder-api-types": "1.7.1",
     "string-template": "^1.0.0",
     "typescript": "~4.0.0"
   },

--- a/packages/generic/core/src/modules/document/documentType.ts
+++ b/packages/generic/core/src/modules/document/documentType.ts
@@ -206,7 +206,7 @@ const checklistModel = {
   content: {
     kind: 'object',
     content: {
-      checkType: {
+      check_type: {
         kind: 'primitive',
         content: 'string',
       },

--- a/packages/generic/core/src/modules/document/documentType.ts
+++ b/packages/generic/core/src/modules/document/documentType.ts
@@ -228,28 +228,16 @@ const checklistModel = {
         },
       },
       sentences: {
-        kind: 'or',
-        content: [
-          {
-            kind: 'array',
-            content: {
-              kind: 'object',
-              content: {
-                start: { kind: 'primitive', content: 'number' },
-                end: { kind: 'primitive', content: 'number' },
-              },
-            },
+        kind: 'array',
+        content: {
+          kind: 'object',
+          content: {
+            start: { kind: 'primitive', content: 'number' },
+            end: { kind: 'primitive', content: 'number' },
           },
-          { kind: 'primitive', content: 'undefined' },
-        ],
+        },
       },
-      metadata_text: {
-        kind: 'or',
-        content: [
-          { kind: 'array', content: { kind: 'primitive', content: 'string' } },
-          { kind: 'primitive', content: 'undefined' },
-        ],
-      },
+      metadata_text: { kind: 'array', content: { kind: 'primitive', content: 'string' } },
     },
   },
 } as const;

--- a/packages/generic/core/src/modules/document/generator/documentGenerator.ts
+++ b/packages/generic/core/src/modules/document/generator/documentGenerator.ts
@@ -7,7 +7,7 @@ export { documentGenerator, decisionMetadataGenerator, checklistGenerator };
 const checklistGenerator = {
   generate(size: number): documentType['checklist'] {
     return Array.from({ length: size }, () => ({
-      checkType: `CHECK_TYPE_${Math.random()}`,
+      check_type: `CHECK_TYPE_${Math.random()}`,
       message: "Default message: L'annotation 'Test' est présente dans différentes catégories.",
       short_message: 'Default short message: Annotation dans plusieurs catégories ?',
       entities: [

--- a/packages/generic/core/src/modules/treatment/lib/concat.spec.ts
+++ b/packages/generic/core/src/modules/treatment/lib/concat.spec.ts
@@ -106,4 +106,47 @@ describe('concat', () => {
       },
     ]);
   });
+  it('should return a checklist in the NLP treatment', () => {
+    const checklist = [
+      {
+        check_type: 'check',
+        message: 'message',
+        short_message: 'short message',
+        entities: [],
+        sentences: [],
+        metadata_text: [],
+      },
+    ];
+    const document = documentModule.generator.generate();
+    const treatments: treatmentType[] = [
+      {
+        subAnnotationsSensitiveCount: 5,
+        documentId: document._id,
+        order: 1,
+        source: 'annotator' as treatmentType['source'],
+        lastUpdateDate: 1720776507700,
+      },
+      { documentId: document._id, order: 0, source: 'NLP' as treatmentType['source'], lastUpdateDate: 1720773507000 },
+    ].map(treatmentModule.generator.generate);
+
+    const labelTreatments = concat(treatments, nlpVersion, checklist);
+
+    expect(labelTreatments).toEqual([
+      {
+        annotations: [],
+        order: 1,
+        source: 'NLP',
+        treatmentDate: '2024-07-12T08:38:27.000Z',
+        version: nlpVersion,
+        checklist: checklist,
+      },
+      {
+        annotations: [],
+        order: 2,
+        source: 'LABEL_WORKING_USER_TREATMENT',
+        treatmentDate: '2024-07-12T09:28:27.700Z',
+        version: undefined,
+      },
+    ]);
+  });
 });

--- a/packages/generic/core/src/modules/treatment/lib/concat.ts
+++ b/packages/generic/core/src/modules/treatment/lib/concat.ts
@@ -5,7 +5,11 @@ import { LabelTreatment } from 'dbsder-api-types';
 
 export { concat };
 
-function concat(treatments: treatmentType[], nlpVersions?: documentType['nlpVersions']): LabelTreatment[] {
+function concat(
+  treatments: treatmentType[],
+  nlpVersions?: documentType['nlpVersions'],
+  checklist?: documentType['checklist'],
+): LabelTreatment[] {
   const labelTreatments: LabelTreatment[] = [];
 
   const sortedTreatments = treatments.sort((treatment1, treatment2) => treatment1.order - treatment2.order);
@@ -19,7 +23,8 @@ function concat(treatments: treatmentType[], nlpVersions?: documentType['nlpVers
         annotations: computeAnnotations(sortedTreatments),
         source: computeSource(currentTreatment.source),
         order,
-        version: currentTreatment.source == 'NLP' ? nlpVersions : undefined,
+        version: currentTreatment.source === 'NLP' ? nlpVersions : undefined,
+        checklist: currentTreatment.source === 'NLP' ? checklist : undefined,
         treatmentDate: new Date(currentTreatment.lastUpdateDate).toISOString(),
       });
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6768,10 +6768,10 @@ dateformat@^5.0.3:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-5.0.3.tgz#fe2223eff3cc70ce716931cb3038b59a9280696e"
   integrity sha512-Kvr6HmPXUMerlLcLF+Pwq3K7apHpYmGDVqrxcDasBg86UcKeTSNWbEzU8bwdXnxnR44FtMhJAxI4Bov6Y/KUfA==
 
-dbsder-api-types@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/dbsder-api-types/-/dbsder-api-types-1.7.0.tgz#68df88e6ee741f849a76717e67f758798b808046"
-  integrity sha512-vbko8KCaX0bP9NHxjIIjmR8/NefA32/s7HvmBFoD7lwhI8oXrU6cfFzzjf1Htc3cOYyNrVnFD7Z3IeVLD/0qbw==
+dbsder-api-types@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/dbsder-api-types/-/dbsder-api-types-1.7.1.tgz#9a4f950de094723ed7464b96d5e765937d2eff1f"
+  integrity sha512-FkOndc9U4Dk8LI06XN+3CZS0cSP4AP0D37sTcCCWA90XuSG7uK1zDsfxHd4bfsuQ0w+8bUeeV6Bixe936MBONA==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
- export checklist in NLP labelTreatement 
- import checklist when reimport document with keepLabelTreatment flag
linked with https://github.com/Cour-de-cassation/dbsder-api/pull/152

