### PR TITLE
Feat/ctrl y

### DIFF
--- a/packages/generic/client/src/pages/Home/DocumentAnnotator/DocumentAnnotator.tsx
+++ b/packages/generic/client/src/pages/Home/DocumentAnnotator/DocumentAnnotator.tsx
@@ -17,7 +17,7 @@ function DocumentAnnotator(props: { onStopAnnotatingDocument?: () => Promise<voi
   const annotatorStateHandler = useAnnotatorStateHandler();
   useKeyboardShortcutsHandler([
     { key: 'z', ctrlKey: true, action: onRevertState },
-    { key: 'Z', ctrlKey: true, shiftKey: true, action: onRestoreState },
+    { key: 'y', ctrlKey: true, action: onRestoreState },
   ]);
   const viewerRef = useRef(null);
 

--- a/packages/generic/client/src/pages/Home/DocumentAnnotator/hooks/useKeyboardShortcutsHandler.ts
+++ b/packages/generic/client/src/pages/Home/DocumentAnnotator/hooks/useKeyboardShortcutsHandler.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 export { useKeyboardShortcutsHandler };
 
-type shortcutType = { key: string; ctrlKey?: boolean; shiftKey?: boolean; action: () => void };
+type shortcutType = { key: string; ctrlKey?: boolean; action: () => void };
 
 function useKeyboardShortcutsHandler(shortcuts: shortcutType[]): void {
   useEffect(() => {
@@ -12,8 +12,7 @@ function useKeyboardShortcutsHandler(shortcuts: shortcutType[]): void {
 
   function onKeyDown(event: KeyboardEvent) {
     shortcuts.forEach((shortcut) => {
-      const doesShortcutMatch =
-        shortcut.key === event.key && !!shortcut.ctrlKey === event.ctrlKey && !!shortcut.shiftKey === event.shiftKey;
+      const doesShortcutMatch = shortcut.key === event.key && !!shortcut.ctrlKey === event.ctrlKey;
       if (doesShortcutMatch) {
         shortcut.action();
       }


### PR DESCRIPTION
## Issue description :
Ajout du ctrl-y pour rétablir l'état d'avant
## Describe your changes :
J'ai juste adapté la commande ctrl+shift+Z en ctrl-y
## How to test :
Allez en vue annotator, faire des changements et jouer avec la commande ctrl-y / ctrl-z
**NB : en local, nous ne pouvons pas faire un ctrl-y / ctrl-z sans fin (sinon erreur et label plante => faut juste recharger la page : comportement vue que en local) et ce comportement était là depuis toujours, en revanche, nous n'avons pas le même comportement en dev, preprod, prod (nous avons dans la console juste le message d'erreur et label ne plante pas)**
## Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [X] The feature works locally.
- [ ] If it's relevant I added tests.
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
