### PR TITLE
Hotfix stats fetching

### DIFF
--- a/packages/generic/backend/src/modules/ressourceFilter/repository/buildRessourceFilterRequest.ts
+++ b/packages/generic/backend/src/modules/ressourceFilter/repository/buildRessourceFilterRequest.ts
@@ -38,6 +38,12 @@ function buildRessourceFilterRequest(
       ...ressourceFilterRequest.treatmentDate,
       $gt: ressourceFilter.startDate,
     };
+  } else {
+    // Prevent fetching too old data by default
+    ressourceFilterRequest.treatmentDate = {
+      ...ressourceFilterRequest.treatmentDate,
+      $gt: Date.now() - 6 * 30 * 24 * 60 * 60 * 1000, // 6 months in milliseconds
+    };
   }
 
   if (ressourceFilter.endDate) {

--- a/packages/generic/backend/src/modules/statistic/repository/buildFakeStatisticRepository.ts
+++ b/packages/generic/backend/src/modules/statistic/repository/buildFakeStatisticRepository.ts
@@ -1,6 +1,7 @@
 import { statisticType } from '@label/core';
 import {
   buildFakeRepositoryBuilder,
+  projectFakeObjects,
   updateFakeCollection,
 } from '../../../repository';
 import { buildFakeRessourceFilterRequest } from '../../ressourceFilter';
@@ -60,6 +61,12 @@ const buildFakeStatisticRepository = buildFakeRepositoryBuilder<
         }),
       );
       return modifiedCount;
+    },
+
+    async findRecentStatisticsProjection(projections) {
+      return collection.map((statistic) =>
+        projectFakeObjects(statistic, projections),
+      );
     },
   }),
 });

--- a/packages/generic/backend/src/modules/statistic/repository/buildStatisticRepository.ts
+++ b/packages/generic/backend/src/modules/statistic/repository/buildStatisticRepository.ts
@@ -75,5 +75,13 @@ const buildStatisticRepository = buildRepositoryBuilder<
       );
       return result.modifiedCount;
     },
+
+    async findRecentStatisticsProjection(projections) {
+      const sixMonthsAgo = Date.now() - 6 * 30 * 24 * 60 * 60 * 1000; // 6 months in milliseconds
+      return await collection
+        .find({ treatmentDate: { $gte: sixMonthsAgo } })
+        .project(projections)
+        .toArray();
+    },
   }),
 });

--- a/packages/generic/backend/src/modules/statistic/repository/customStatisticRepositoryType.ts
+++ b/packages/generic/backend/src/modules/statistic/repository/customStatisticRepositoryType.ts
@@ -1,4 +1,5 @@
 import { idType, ressourceFilterType, statisticType } from '@label/core';
+import { projectedType } from '../../../repository';
 
 export type { customStatisticRepositoryType };
 
@@ -15,4 +16,7 @@ type customStatisticRepositoryType = {
     sources: statisticType['source'][],
   ) => Promise<{ minDate: number | undefined; maxDate: number | undefined }>;
   deleteTreatmentsSummaryByIds: (ids: idType[]) => Promise<number>;
+  findRecentStatisticsProjection: <projectionT extends keyof statisticType>(
+    projections: Array<projectionT>,
+  ) => Promise<Array<projectedType<statisticType, projectionT>>>;
 };

--- a/packages/generic/backend/src/modules/statistic/service/fetchAvailableStatisticFilters.ts
+++ b/packages/generic/backend/src/modules/statistic/service/fetchAvailableStatisticFilters.ts
@@ -9,13 +9,9 @@ export { fetchAvailableStatisticFilters };
 async function fetchAvailableStatisticFilters() {
   const statisticRepository = buildStatisticRepository();
 
-  const statisticFields = await statisticRepository.findAllProjection([
-    'publicationCategory',
-    'route',
-    'importer',
-    'source',
-    'jurisdiction',
-  ]);
+  const statisticFields = await statisticRepository.findRecentStatisticsProjection(
+    ['publicationCategory', 'route', 'importer', 'source', 'jurisdiction'],
+  );
 
   const availableDocumentSources = await documentService.fetchAllSources();
   const { minDate, maxDate } = await fetchExtremumDates(


### PR DESCRIPTION
## Issue description :
Boubacar 
Lorsque la collection statistics contient plus de 5 000 documents, certaines opérations entraînent une erreur JavaScript heap out of memory. Cela empêchait le traitement ou génère le bandeau rouge.

## Describe your changes :
ne charger que les 6 derniers mois " const sixMonthsAgo = Date.now() - 6 * 30 * 24 * 60 * 60 * 1000; // 6 months in milliseconds
      return await collection
        .find({ treatmentDate: { $gte: sixMonthsAgo } })
        .project(projections)
        .toArray();
    },"
## How to test :
En locale, j'ai changer le scripte refreshDate des seed pour avoir au moins plus de 5K de stats mais le problème à l'origine est difficile à reproduire en locale.
## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] The feature works locally.
- [ ] If it's relevant I added tests.
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
