### PR TITLE
blocking tcom import because problem of normalisation

### DIFF
--- a/packages/generic/backend/src/lib/connector/buildConnector.ts
+++ b/packages/generic/backend/src/lib/connector/buildConnector.ts
@@ -195,7 +195,11 @@ function buildConnector(connectorConfig: connectorConfigType) {
       msg: `Starting importNewDocuments...`,
     });
 
-    for (const source of Object.values(Deprecated.Sources)) {
+    // on bloque les decisions Deprecated.Sources.TCOM pour l'instant car la normalisation n'est pas encore propre
+    const sources = Object.values(Deprecated.Sources).filter(
+      (src) => src !== Deprecated.Sources.TCOM,
+    );
+    for (const source of sources) {
       logger.log({
         operationName: 'importNewDocuments',
         msg: `Fetching ${source} decisions...`,


### PR DESCRIPTION
## Issue description :
Blocking tcom import in label
## Describe your changes :
adding logic to skip juritcomimport
## How to test :
run dbsder-api and lebel, execute script => scripts/runScriptLocally.sh "autoImportDocumentsFromSder.js" and look at after imorted documents sources
## Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [X] The feature works locally.
- [ ] If it's relevant I added tests.
- [X] Will this be part of a product update? If yes, please write one phrase about this update.
